### PR TITLE
Fidelity and random improvements

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -14,15 +14,16 @@ void main() {
   });
 }
 
-void sayHello(Request req, Response res) {
+void sayHello(Request req, Response res, next) {
   res.send('Hello ${req.params['name']}');
 }
 
 void checkName(Request req, Response res, next) {
   if (req.params['name'] != 'Alberto') {
     res.send('Only Alberto is allowed to use this action');
+  } else {
+    next();
   }
-  next();
 }
 
 void changeName(Request req, Response res, next) {

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -1,20 +1,40 @@
 import 'dart:io';
 
 class Response {
-  Response();
   HttpResponse _httpResponse;
   bool _closed = false;
   bool get closed => _closed;
 
-  void send(Object data) {
-    _httpResponse.write(data);
+  Response([HttpResponse existingResponse]) {
+    this._httpResponse = existingResponse;
+  }
+
+  /// This method will throw an exception when called if the response has already
+  /// been closed. Call this before running all methods where the request is
+  /// being modified, because the exception will bubble up.
+  /// It may be a good idea in the future to create new exception classes extending
+  /// Exception so they can be caught separately or used with `is`
+  void _checkResponseClosed() {
+    if (closed) {
+      throw new Exception('Can\'t modify request after it has already been closed');
+    }
+  }
+
+  /// Call this when the http response is done being modified, and should
+  /// be closed.
+  void _finish() {
     _httpResponse.close();
     _closed = true;
   }
 
+  void send(Object data) {
+    _checkResponseClosed();
+
+    _httpResponse.write(data);
+    _finish();
+  }
+
   static Response from(HttpResponse httpResponse) {
-    Response newResponse = Response();
-    newResponse._httpResponse = httpResponse;
-    return newResponse;
+    return Response(httpResponse);
   }
 }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -34,6 +34,17 @@ class Response {
     _finish();
   }
 
+
+  void statusCode(int statusCode) {
+    _checkResponseClosed();
+
+    if (statusCode < 100 || statusCode > 600) {
+      throw new Exception('Status code $statusCode invalid: out of range [100, 600]');
+    }
+
+    _httpResponse.statusCode = statusCode;
+  }
+
   static Response from(HttpResponse httpResponse) {
     return Response(httpResponse);
   }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -35,7 +35,7 @@ class Response {
   }
 
 
-  void statusCode(int statusCode) {
+  void statusCode([int statusCode = HttpStatus.ok]) {
     _checkResponseClosed();
 
     if (statusCode < 100 || statusCode > 600) {

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -45,6 +45,12 @@ class Response {
     _httpResponse.statusCode = statusCode;
   }
 
+  void addHeader(String name, Object value) {
+    _checkResponseClosed();
+
+    _httpResponse.headers.add(name, value);
+  }
+
   static Response from(HttpResponse httpResponse) {
     return Response(httpResponse);
   }


### PR DESCRIPTION
* Response code cleanup
* Response.statusCode
* Response.addHeader
* RouteCallback functions now must take next()
    * In the express API, next() just moves to the next middleware. Doesn't matter if the request has already closed, etc., it moves to the next. So this PR also adds that
    * This should also be handling route next() calls. Again, with the express API the routes themselves are middleware. So this means you can have two routes match the same path and if you call next() it should move to the next one that matches (or leave the response open if no other one does)
* Response no longer allows calling methods like `send` more than once
* Routes are now considered their own middleware
* Middlewares are no longer all executed at once. They wait for next() to be called

Some notes:
* Like I said, the routes should be considered middleware themselves, and be able to handle next()
* It would be useful to allow regex as route names rather than exact matches
* Routers are also very important to make the system modular, and makes it easier for matching 